### PR TITLE
Removed concepts #5; Improved Colour Text Algorithm

### DIFF
--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -1,5 +1,4 @@
 #include "animation.hpp"
-#include <iostream>
 
 namespace Application::Helper {
 	void Animation::addAnimation(int frames, int x, int y, int w, int h) {
@@ -29,6 +28,9 @@ namespace Application::Helper {
 		if (scale != 0) {
 			dst.w *= static_cast<int>(scale);
 			dst.h *= static_cast<int>(scale);
+		} else if (scale < 0) {
+			dst.w *= 1;
+			dst.h *= 1;
 		}
 
 		SDL_RenderCopy(ren, img->texture.get(), &clip, &dst);

--- a/src/animation.hpp
+++ b/src/animation.hpp
@@ -5,12 +5,12 @@
 #include <map>
 #include <string>
 
-// add a sprite sheet and iterate over it (assuming the spritesheet is exactly the same width and height)
+// add a spritesheet and iterate over it (assuming the spritesheet is exactly the same width and height)
+// TODO: redo this
 
 namespace Application::Helper {
 	class Animation {
 	public:
-		//constexpr uint32_t getCurrentFrame();
 		/** Quick animation creation
 		 *
 		 * \param frames -> number of frames in the gif extraction
@@ -21,18 +21,26 @@ namespace Application::Helper {
 		 * \return void -> no return available.
 		 */
 		void addAnimation(int frames, int x, int y, int w, int h);
-		//void setCurrentFrame(std::string_view frameName);
-		//void stopAnimation();
-		
-		// speed -> how fast the animation should play
+		/** Updates the animation frames
+		 *
+		 * \param speed -> how fast the animation should play
+		 * \param dt -> deltaTime from the main loop
+		 */
 		void update(float speed, double dt);
+		/** Renders the animation to the screen
+		 * 
+		 * \param img -> the button to draw
+		 * \param ren -> the renderer to use
+		 * \param x -> x position of the animation
+		 * \param y -> y position of the animation
+		 * \param scale -> scale the animation width and height up or down (0 is the lowest it can go)
+		 */
 		void draw(IMD &img, SDL_Renderer *ren, int x, int y, double scale = 0.0);
 
 	private:
 		float frameTime {0.0f};
 		int currentFrame {0};
 		std::basic_string<char> animStr {};
-		// make this an unordered_map?
 		std::map<unsigned int, SDL_Rect> frames {};
 	};
 } // namespace Application::Helper

--- a/src/anya.hpp
+++ b/src/anya.hpp
@@ -20,7 +20,7 @@
 // at its current state, it takes 3.6mb on debug, too high. (11mb with gif alloc)
 
 namespace Application {
-	using namespace Helper::Utilities;
+	using namespace Helper::Utils;
 
 	class Anya final {
 	public:
@@ -48,7 +48,7 @@ namespace Application {
 		uint32_t windowHeight {89};
 		std::chrono::steady_clock::time_point begin {};
 		std::chrono::steady_clock::time_point end {};
-		std::chrono::duration<double, std::milli> deltaTime {};
+		double deltaTime {};
 		int FPS {30};
 		const int delay {1000 / FPS};
 
@@ -61,29 +61,27 @@ namespace Application {
 		std::basic_string<char> typographyStr {};
 		std::basic_stringstream<char> str {};
 		// set background colour
-		int rVal {0};
-		int gVal {0};
-		int bVal {0};
+		int redViewColor {0};
+		int greenViewColor {0};
+		int blueViewColor {0};
 
 		bool setTypographyIsPressed {false};
 		// setBG button on/off
 		bool setBGIsPressed {false};
 		// setBGColor button on/off
 		bool setBGToColor {false};
+		bool setBGtoImg {false};
 		bool minimalMode {false};
 		bool showDate {false};
 		bool setThemeIsPressed {false};
-
 		bool inColorPickerBounds {false};
 
-		float sceneAlpha {SDL_ALPHA_TRANSPARENT};
-
+		// window draggable
 		SDL_Rect dragRect {0, 0, 50, 10};
-
+		// scene view separators 
 		SDL_Rect settingsView {0, 0, (int)windowWidth, (int)windowHeight};
 		SDL_Rect settingsThemesView {0, 0, (int)windowWidth, (int)windowHeight};
 		SDL_Rect fillBGColor {0, 0, (int)windowWidth, (int)windowHeight};
-
 		// add an colour alpha slider
 		SDL_Rect colorPickerBounds = {(int)(windowWidth / 2) + 9, 0, 65, (int)windowWidth / 2};
 		SDL_Rect colorSliderBounds = {(int)(windowWidth / 2), 0, 8, 89};
@@ -161,7 +159,6 @@ namespace Application {
 		// set the enter key to submit the value based on the button selected
 		Helper::BUTTONPTR buttonColorInputBtn {nullptr};
 		////////////////////////////////
-		
 	};
 } // namespace Application
 

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -27,7 +27,7 @@ namespace Application::Helper {
 		if (key != nullptr)
 			SDL_SetColorKey(surf, SDL_TRUE, SDL_MapRGB(surf->format, key->r, key->g, key->b));
 
-		newImage->texture = Utilities::PTR<SDL_Texture>(SDL_CreateTextureFromSurface(ren, surf));
+		newImage->texture = Utils::PTR<SDL_Texture>(SDL_CreateTextureFromSurface(ren, surf));
 		if (newImage->texture == nullptr) {
 			std::cout << "Failed to create image: " << SDL_GetError() << '\n';
 			return nullptr;
@@ -42,7 +42,7 @@ namespace Application::Helper {
 	IMD Image::createRenderTarget(SDL_Renderer *ren, unsigned int width, unsigned int height) {
 		IMD newImage = std::make_shared<ImageData>();
 
-		newImage->texture = Utilities::PTR<SDL_Texture>(SDL_CreateTexture(ren, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET, width, height));
+		newImage->texture = Utils::PTR<SDL_Texture>(SDL_CreateTexture(ren, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET, width, height));
 		if (newImage->texture == nullptr) {
 			std::cout << "Render Target failed to be created: " << SDL_GetError() << '\n';
 			return nullptr;
@@ -68,7 +68,7 @@ namespace Application::Helper {
 			return nullptr;
 		}
 
-		newImage->texture = Utilities::PTR<SDL_Texture>(SDL_CreateTextureFromSurface(ren, surf));
+		newImage->texture = Utils::PTR<SDL_Texture>(SDL_CreateTextureFromSurface(ren, surf));
 		if (newImage->texture == nullptr) {
 			std::cout << "Text texture failed to be created: " << TTF_GetError() << '\n';
 			return nullptr;
@@ -107,7 +107,7 @@ namespace Application::Helper {
 		SDL_Rect position = {position.x = 1, position.y = 1, fgSurf->w, fgSurf->h};
 		SDL_BlitSurface(bgSurf, nullptr, fgSurf, &position);
 
-		newImage->texture = Utilities::PTR<SDL_Texture>(SDL_CreateTextureFromSurface(ren, fgSurf));
+		newImage->texture = Utils::PTR<SDL_Texture>(SDL_CreateTextureFromSurface(ren, fgSurf));
 		if (newImage->texture == nullptr) {
 			std::cout << "Outline text texture failed to be created: " << TTF_GetError() << '\n';
 			return nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "anya.hpp"
 
 using namespace Application;
+
 int main(int, char **)
 {
 	auto inst = Anya();

--- a/src/mbstyle.cpp
+++ b/src/mbstyle.cpp
@@ -1,0 +1,6 @@
+// set the style of the windows message box
+#if defined _WIN64
+#pragma comment(linker, "/manifestdependency:\"type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='amd64' publicKeyToken='6595b64144ccf1df' language='*'\"")
+#else
+#pragma comment(linker, "/manifestdependency:\"type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
+#endif

--- a/src/scene.hpp
+++ b/src/scene.hpp
@@ -9,8 +9,9 @@ namespace Application::Helper {
 	public:
 		~Scene() { sceneList.clear(); }
 
-		void createScene(std::string_view name);
-		void setScene(std::string_view name);
+		constexpr void createScene(std::string_view name);
+		constexpr void setScene(std::string_view name);
+		constexpr void printScene();
 		constexpr uint64_t getCurrentScene();
 		constexpr uint64_t findScene(std::string_view name);
 

--- a/src/scene.inl
+++ b/src/scene.inl
@@ -1,16 +1,23 @@
-#include <iostream>
+#include "scene.hpp"
 
 namespace Application::Helper {
-	inline void Scene::createScene(std::string_view name) {
+	inline constexpr void Scene::createScene(std::string_view name) {
 		sceneList.emplace_back(name);
 	}
 
-	inline void Scene::setScene(std::string_view name) {
+	inline constexpr void Scene::setScene(std::string_view name) {
 		const auto it = std::find(sceneList.begin(), sceneList.end(), name);
 		const auto sceneIndex = it - sceneList.begin();
+
 		currentScene = sceneIndex;
 
-		std::cout << "Current Scene: " << currentScene << ", " << name << '\n';
+#ifdef _DEBUG
+		printScene();
+#endif
+	}
+
+	inline constexpr void Scene::printScene() {
+		Utils::println(sceneList[currentScene]);
 	}
 
 	inline constexpr uint64_t Scene::getCurrentScene() {

--- a/src/uinterface.cpp
+++ b/src/uinterface.cpp
@@ -1,8 +1,5 @@
 #include "uinterface.hpp"
 #include "util.hpp"
-#include <cassert>
-#include <iostream>
-#include <format>
 
 namespace Application::Helper {
 	BUTTONPTR UInterface::createButton(std::string_view text, IMD texture, int x, int y, uint32_t w, uint32_t h) {

--- a/src/uinterface.hpp
+++ b/src/uinterface.hpp
@@ -2,9 +2,8 @@
 
 #include <SDL.h>
 #include "data.hpp"
-#include <nfd.h>
 #include <string>
-#include <unordered_map>
+#include <vector>
 
 namespace Application::Helper {
 	struct Button {

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -2,22 +2,23 @@
 
 #include <SDL.h>
 #include <memory>
-#include <concepts>
+#include <iostream>
 
-namespace Application::Helper::Utilities {
+namespace Application::Helper::Utils {
 	struct Memory final {
-		void operator()(SDL_Window *x) const {SDL_DestroyWindow(x);}
-		void operator()(SDL_Renderer *x) const {SDL_DestroyRenderer(x);}
-		void operator()(SDL_Texture *x) const {SDL_DestroyTexture(x);}
+		void operator()(SDL_Window *x) const { SDL_DestroyWindow(x); }
+		void operator()(SDL_Renderer *x) const { SDL_DestroyRenderer(x); }
+		void operator()(SDL_Texture *x) const { SDL_DestroyTexture(x); }
 	};
 
-	template <typename T> using PTR = std::unique_ptr<T, Memory>;
+	template <class T> using PTR = std::unique_ptr<T, Memory>;
 
-	constexpr bool isUnsigned(std::unsigned_integral auto val) noexcept {
-		return (val) ? true : false;
+	template <class T> constexpr void println(T &&var) {
+		std::cout << std::forward<T>(var) << '\n';
 	}
 
-	constexpr bool isUnsigned(std::unsigned_integral auto val1, std::unsigned_integral auto val2) noexcept {
-		return ((val1) && (val2)) ? true : false;
+	template <class T, class... U> constexpr void println(T &&var, U &&...args) {
+		std::cout << std::forward<T>(var);
+		((std::cout << ", " << std::forward<U>(args)), ...);
 	}
 } // namespace Application::Helper::Utilities


### PR DESCRIPTION
- #### Added option to change background image with file dialog (previously partially added in #31)
- #### Fixed issue in #12 where `std::remove` would only move up the stack and caused duplication in string

- #### Improved algorithm for background colour [*(this)*](https://github.com/inohime/Time/blob/main/src/anya.cpp#L341)  by implementing 3 new edge cases:
    1. Checks if there are no spaces in the string. If there are, append spaces appropriately
    2. Checks if the RGB sections in the string are less than 1 or greater than 3. If the input is out of bounds, throw an error.
    3. Checks if there is a comma within the string. If there isn't, throw an error.

- #### Added `println` to utilities (due to MSVC `C3615` which is incorrect [compared to this](https://wandbox.org/permlink/iwH9U1TCY48HdYDE))
    - All functions in `Scene.inl` are now constant expressions 🥳

- #### Small additions/changes:
    - Added documentation to Animation
    - Improved boot error [*(this)*](https://github.com/inohime/Time/blob/main/src/anya.cpp#L9)
    - Minimal mode background colour is now changed with `Set BG`
    - Typography input button now checks for a `.ttf` extension before accepting
    - Added WINAPI `MessageBox` style update
    - Removed `isUnsigned` function in utilities from #5