### PR TITLE
Added prettier memory managed function for PTR

### DIFF
--- a/src/anya.cpp
+++ b/src/anya.cpp
@@ -25,12 +25,6 @@ namespace Application {
 		}
 	}
 
-#ifdef _DEBUG
-	Anya::Anya(const std::chrono::system_clock::time_point &time) {
-		str << timeToStr(time);
-	}
-#endif
-
 	// make this a cross platform function (void * for handle)
 #ifdef _WIN32 
 	static void setWindowShadow(HWND handle, const MARGINS &margins) {
@@ -50,11 +44,11 @@ namespace Application {
 
 		SDL_SetHintWithPriority("SDL_BORDERLESS_WINDOWED_STYLE", "1", SDL_HINT_OVERRIDE);
 
-		window = PTR<SDL_Window>(SDL_CreateWindow(title.c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, 0));
-		renderer = PTR<SDL_Renderer>(SDL_CreateRenderer(window.get(), -1, SDL_RENDERER_SOFTWARE));
+		window = cheesecake(SDL_CreateWindow(title.c_str(), SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, windowWidth, windowHeight, 0));
+		renderer = cheesecake(SDL_CreateRenderer(window.get(), -1, SDL_RENDERER_SOFTWARE));
 		if (!window || !renderer) {
 			errStr = SDL_GetError();
-			std::cout << "failed to boot: " << errStr << '\n';
+			std::cout << "Failed to boot: " << errStr << '\n';
 			free();
 			return shouldRun;
 		}
@@ -776,10 +770,5 @@ namespace Application {
 		} else {
 			return std::format("{:%OI:%M}AM", std::chrono::current_zone()->to_local(time));
 		}
-	}
-
-	std::unique_ptr<std::basic_stringstream<char>> Anya::getStream() {
-		auto ptr = std::make_unique<std::basic_stringstream<char>>(std::move(str));
-		return ptr;
 	}
 } // namespace Application

--- a/src/anya.hpp
+++ b/src/anya.hpp
@@ -7,8 +7,6 @@
 #include "scene.hpp"
 #include <chrono>
 #include <format>
-#include <sstream>
-#include <functional>
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <dwmapi.h>
@@ -25,12 +23,8 @@ namespace Application {
 	class Anya final {
 	public:
 		Anya();
-#ifdef _DEBUG
-		Anya(const std::chrono::system_clock::time_point &time);
-#endif
 
 		std::basic_string<char> timeToStr(const std::chrono::system_clock::time_point &time);
-		std::unique_ptr<std::basic_stringstream<char>> getStream();
 		bool boot();
 		void update();
 		void draw();
@@ -40,8 +34,8 @@ namespace Application {
 		// window data
 		std::basic_string<char> title {"anya"};
 		std::basic_string<char> errStr {};
-		PTR<SDL_Window> window {nullptr};
-		PTR<SDL_Renderer> renderer {nullptr};
+		SMD<SDL_Window> window {nullptr};
+		SMD<SDL_Renderer> renderer {nullptr};
 		SDL_Event ev {};
 		bool shouldRun {false};
 		uint32_t windowWidth {148};
@@ -59,7 +53,6 @@ namespace Application {
 		// directory path
 		std::basic_string<char> dirPath {};
 		std::basic_string<char> typographyStr {};
-		std::basic_stringstream<char> str {};
 		// set background colour
 		int redViewColor {0};
 		int greenViewColor {0};
@@ -155,7 +148,6 @@ namespace Application {
 		Helper::BUTTONPTR setButtonOCBtn {nullptr};
 		Helper::BUTTONPTR setButtonTCBtn {nullptr};
 		Helper::BUTTONPTR exitThemeCreatorBtn {nullptr};
-		// reuse input button for each button colour
 		// set the enter key to submit the value based on the button selected
 		Helper::BUTTONPTR buttonColorInputBtn {nullptr};
 		////////////////////////////////

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -3,10 +3,12 @@
 #include <filesystem>
 #include <iostream>
 
+using namespace Application::Helper::Utils;
+
 namespace Application::Helper {
 	SDL_Surface *loadFile(std::string_view filePath) {
 		if (filePath.data() == nullptr) {
-			Utils::panicln("Failed to load file");
+			panicln("Failed to load file");
 			return nullptr;
 		}
 
@@ -26,9 +28,9 @@ namespace Application::Helper {
 		if (key != nullptr)
 			SDL_SetColorKey(surf, SDL_TRUE, SDL_MapRGB(surf->format, key->r, key->g, key->b));
 
-		newImage->texture = Utils::PTR<SDL_Texture>(SDL_CreateTextureFromSurface(ren, surf));
+		newImage->texture = cheesecake(SDL_CreateTextureFromSurface(ren, surf));
 		if (newImage->texture == nullptr) {
-			Utils::panicln("Failed to create image");
+			panicln("Failed to create image");
 			return nullptr;
 		}
 		images.insert({filePath.data(), newImage});
@@ -41,9 +43,9 @@ namespace Application::Helper {
 	IMD Image::createRenderTarget(SDL_Renderer *ren, unsigned int width, unsigned int height) {
 		IMD newImage = std::make_shared<ImageData>();
 
-		newImage->texture = Utils::PTR<SDL_Texture>(SDL_CreateTexture(ren, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET, width, height));
+		newImage->texture = cheesecake(SDL_CreateTexture(ren, SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_TARGET, width, height));
 		if (newImage->texture == nullptr) {
-			Utils::panicln("Render Target failed to be created");
+			panicln("Render Target failed to be created");
 			return nullptr;
 		}
 
@@ -56,20 +58,20 @@ namespace Application::Helper {
 
 		TTF_Font *font = TTF_OpenFont(msg.fontFile.data(), msg.fontSize);
 		if (font == nullptr) {
-			Utils::panicln("TTF_OpenFont error");
+			panicln("TTF_OpenFont error");
 			return nullptr;
 		}
 
 		SDL_Surface *surf = TTF_RenderText_Blended(font, msg.msg.data(), msg.col.textColor);
 		if (surf == nullptr) {
 			TTF_CloseFont(font);
-			Utils::panicln("TTF_RenderText error");
+			panicln("TTF_RenderText error");
 			return nullptr;
 		}
 
-		newImage->texture = Utils::PTR<SDL_Texture>(SDL_CreateTextureFromSurface(ren, surf));
+		newImage->texture = cheesecake(SDL_CreateTextureFromSurface(ren, surf));
 		if (newImage->texture == nullptr) {
-			Utils::panicln("Failed to create text image");
+			panicln("Failed to create text image");
 			return nullptr;
 		}
 		//TTF_SizeText(font, msg.msg.data(), &newImage->imageWidth, &newImage->imageHeight); bug
@@ -87,13 +89,13 @@ namespace Application::Helper {
 
 		TTF_Font *font = TTF_OpenFont(msg.fontFile.data(), msg.fontSize);
 		if (font == nullptr) {
-			Utils::panicln("TTF_OpenFont error");
+			panicln("TTF_OpenFont error");
 			return nullptr;
 		}
 
 		TTF_Font *outlineFont = TTF_OpenFont(msg.fontFile.data(), msg.fontSize);
 		if (font == nullptr) {
-			Utils::panicln("TTF_OpenFont error");
+			panicln("TTF_OpenFont error");
 			return nullptr;
 		}
 
@@ -106,9 +108,9 @@ namespace Application::Helper {
 		SDL_Rect position = {position.x = 1, position.y = 1, fgSurf->w, fgSurf->h};
 		SDL_BlitSurface(bgSurf, nullptr, fgSurf, &position);
 
-		newImage->texture = Utils::PTR<SDL_Texture>(SDL_CreateTextureFromSurface(ren, fgSurf));
+		newImage->texture = cheesecake(SDL_CreateTextureFromSurface(ren, fgSurf));
 		if (newImage->texture == nullptr) {
-			Utils::panicln("Failed to create outline text image");
+			panicln("Failed to create outline text image");
 			return nullptr;
 		}
 		images.insert({msg.fontFile, newImage});
@@ -145,12 +147,12 @@ namespace Application::Helper {
 	int Image::add(std::string_view str, IMD &img) {
 		auto iter = images.find(str.data());
 		if (iter != images.end()) {
-			Utils::println("Image already exists");
+			println("Image already exists");
 			return -1;
 		} else {
 			images.insert({str.data(), img});
 			if (images.find(str.data()) != images.end())
-				Utils::println("Created image");
+				println("Created image");
 		}
 
 		return 0;
@@ -161,7 +163,7 @@ namespace Application::Helper {
 			images.erase(img->path);
 			img.reset();
 		} else {
-			Utils::println("Failed to remove image");
+			println("Failed to remove image");
 			return -1;
 		}
 
@@ -230,7 +232,7 @@ namespace Application::Helper {
 	int Image::getPackWidth(std::string_view packName) noexcept {
 		auto findPack = images.find(packName.data());
 		if (findPack == images.end()) {
-			Utils::println("Failed to get pack");
+			println("Failed to get pack");
 			return -1;
 		}
 
@@ -240,7 +242,7 @@ namespace Application::Helper {
 	int Image::getPackHeight(std::string_view packName) noexcept {
 		auto findPack = images.find(packName.data());
 		if (findPack == images.end()) {
-			Utils::println("Failed to get pack");
+			println("Failed to get pack");
 			return -1;
 		}
 
@@ -252,6 +254,6 @@ namespace Application::Helper {
 	}
 
 	constexpr void Image::printImageCount() const noexcept {
-		Utils::println("Image Size", images.size());
+		println("Image Size", images.size());
 	}
 } // namespace Application::Helper

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -11,32 +11,41 @@ namespace Application::Helper::Utils {
 		void operator()(SDL_Renderer *x) const { SDL_DestroyRenderer(x); }
 		void operator()(SDL_Texture *x) const { SDL_DestroyTexture(x); }
 	};
-	/** Memory deleter handle. Used to free SDL window, renderer, and/or textures without the overhead of a shared pointer.
+	/** Memory handler. Used to manage an SDL window, renderer, and/or textures without the overhead of a shared pointer.
 	 * 
-	 * \param T -> the SDL type to manage
+	 * \param T -> SDL type to manage
 	 */
-	template <class T> using PTR = std::unique_ptr<T, Memory>;
-	/** Print lines to the console (works in constexpr functions).
+	template <class T> using SMD = std::unique_ptr<T, Memory>;
+	/** Memory handler function. Used to create & free an SDL window, renderer, and/or textures.
 	 * 
-	 * \param msg -> the msg/variable to print
+	 * \param type -> SDL type to manage
+	 * \return the type in a managed memory wrapper.
 	 */
-	template <class T> constexpr void println(T &&msg) noexcept {
-		std::cout << std::forward<T>(msg) << '\n';
+	template <class T> inline constexpr SMD<T> cheesecake(T *type) {
+		return SMD<T>(type);
 	}
 	/** Print lines to the console (works in constexpr functions).
 	 * 
-	 * \param msg -> the message/variable to print
+	 * \param msg -> message/variable to print
+	 */
+	template <class T> inline constexpr void println(T &&msg) noexcept {
+		std::cout << std::forward<T>(msg) << '\n';
+	}
+	/** Print multiple lines to the console (works in constexpr functions).
+	 * 
+	 * \param msg -> message/variable to print
 	 * \param optMsg -> (optional) additional messages/variables to print
 	 */
-	template <class T, class... U> constexpr void println(T &&msg, U &&...optMsg) noexcept {
+	template <class T, class... U> inline constexpr void println(T &&msg, U &&...optMsg) noexcept {
 		std::cout << std::forward<T>(msg);
 		((std::cout << ", " << std::forward<U>(optMsg)), ...);
+		std::cout << '\n';
 	}
 	/** Print lines and SDL_GetError to the console (works in constexpr functions).
 	 * 
-	 * \param errMsg -> the error message to print
+	 * \param errMsg -> error message to print
 	 */
-	template <class T> constexpr void panicln(T &&errMsg) noexcept {
+	template <class T> inline constexpr void panicln(T &&errMsg) noexcept {
 		std::cout << std::forward<T>(errMsg) << ": " << SDL_GetError() << '\n';
 	}
 } // namespace Application::Helper::Utils


### PR DESCRIPTION
- #### Replaced `PTR<>` for friendlier interface
    1.  PTR renamed to `SMD<>` (SDL memory deleter) 
    2.  `cheesecake` function to wrap SDL types without explicit template specialization (where necessary)

-  #### removed explicit `Utils` namespace scope in Image source